### PR TITLE
Minor update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ipfr
 Title: List Balancing for Reweighting and Population Synthesis
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
   person(
     "Kyle", "Ward", email = "kyleward084@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ipfr 1.0.2 (2020-04-01)
+
+  * Updated tibble subsetting to stay current with the 3.0.0 release
+    of that package.
+
 # ipfr 1.0.1 (2019-12-12)
 
   * Fixed bug when marginal target only had 1 category (#2)

--- a/R/ipu.R
+++ b/R/ipu.R
@@ -527,12 +527,12 @@ check_tables <- function(primary_seed, primary_targets,
 #' @return Nothing. Throws an error if one is found.
 
 check_missing_categories <- function(seed, target, target_name, geo_colname) {
-  
+
   for (geo in unique(unlist(seed[, geo_colname]))){  
     
     # Get column names for the current geo that have a >0 target
-    non_zero_targets <- target[target[geo_colname] == geo,
-                            colSums(target[target[geo_colname] == geo, ]) > 0]
+    non_zero_targets <- target[target[[geo_colname]] == geo,
+                            colSums(target[target[[geo_colname]] == geo, ]) > 0]
     col_names <- colnames(non_zero_targets)
     col_names <- type.convert(col_names[!col_names == geo_colname], as.is = TRUE)
     

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Minor update
-I had to revise a unit test due to the change to class() with respect to
-matrices.
+I had to revise a function given the change to tibble behavior in the 3.0.0
+release.
 
 ## Test environments
 * Windows 10, R 3.6.1 (local)


### PR DESCRIPTION
This minor update keeps ipfr working on CRAN. The tibble package update to 3.0.0 created a small problem.